### PR TITLE
feat: Update CustomIconButton component to use custom icon color

### DIFF
--- a/src/shared/components/CustomIconButton.tsx
+++ b/src/shared/components/CustomIconButton.tsx
@@ -58,9 +58,11 @@ export const CustomIconButton = ({
 					width: "40px",
 				}}
 			>
-				<Icon sx={{ 
-					color: iconColor,
-				 }} />
+				<Icon
+					sx={{
+						color: iconColor,
+					}}
+				/>
 			</IconButton>
 		);
 	}

--- a/src/shared/components/CustomIconButton.tsx
+++ b/src/shared/components/CustomIconButton.tsx
@@ -5,7 +5,7 @@ export const CustomIconButton = ({
 	src,
 	onClick,
 	bgcolor = "primary.main",
-	iconColor = "action",
+	iconColor = "#fff",
 	title,
 	buttonType,
 	disabled,
@@ -13,7 +13,7 @@ export const CustomIconButton = ({
 	src: string | (OverridableComponent<SvgIconTypeMap> & { muiName: string });
 	onClick?: () => void;
 	bgcolor?: string;
-	iconColor?: "primary" | "secondary" | "action" | "disabled" | "error" | undefined;
+	iconColor?: "primary" | "secondary" | "action" | "disabled" | "error" | "#fff";
 	title?: string;
 	buttonType?: "delete" | "normal";
 	disabled?: boolean;
@@ -58,7 +58,9 @@ export const CustomIconButton = ({
 					width: "40px",
 				}}
 			>
-				<Icon color={iconColor} />
+				<Icon sx={{ 
+					color: iconColor,
+				 }} />
 			</IconButton>
 		);
 	}

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -64,7 +64,7 @@ const themeOptions: ThemeOptions = {
 			default: "#fafafa",
 		},
 		action: {
-			active: "#fff",
+			active: "#979797",
 			activatedOpacity: 0.1,
 			selected: "#C0EDED",
 		},

--- a/yarn.lock
+++ b/yarn.lock
@@ -825,9 +825,9 @@
     clsx "^2.1.0"
     prop-types "^15.8.1"
 
-"@mui/core-downloads-tracker@^5.15.19":
+"@mui/core-downloads-tracker@^5.15.18":
   version "5.15.19"
-  resolved "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.19.tgz"
+  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.19.tgz#7af0025c871f126367a55219486681954e4821d7"
   integrity sha512-tCHSi/Tomez9ERynFhZRvFO6n9ATyrPs+2N80DMDzp6xDVirbBjEwhPcE+x7Lj+nwYw0SqFkOxyvMP0irnm55w==
 
 "@mui/icons-material@^5.15.18":


### PR DESCRIPTION
The code changes in `CustomIconButton.tsx` modify the `CustomIconButton` component to allow for a custom icon color. The `iconColor` prop has been updated to accept a hex color value (`#fff`) in addition to the predefined color options. This change provides more flexibility in styling the icon color.

The commit message suggests updating the `CustomIconButton` component to use a custom icon color.